### PR TITLE
Release 1.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,13 +22,6 @@ RUN apk update --no-cache \
     go \
     glide \
 
-    # Cleanup
-    
-    && rm -rf /var/cache/apk/* \
-    && rm -rf /var/lib/apt/lists/* \
-    && rm -rf /tmp/* \
-    && chmod +x /usr/local/bin/run-ssh \
-
     # Make directories
 
     && mkdir -p $GOPATH/bin \
@@ -36,7 +29,14 @@ RUN apk update --no-cache \
 
     # CHMOD
 
-    && chmod -R 777 $GOPATH 
+    && chmod -R 777 $GOPATH \
+
+    # Cleanup
+
+    && rm -rf /var/cache/apk/* \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /tmp/* \
+    && chmod +x /usr/local/bin/run-ssh
 
 WORKDIR /go/src/app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM billyteves/alpine:3.4.0
+FROM billyteves/alpine:3.5.0
 
 MAINTAINER Billy Ray Teves <billyteves@gmail.com>
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,12 +20,6 @@ RUN apk update --no-cache \
     musl-dev \
     musl-utils \
     go \
-    
-    # Added Edge to Install Glide
-
-    && mkdir -p /etc/apk \
-    && echo "http://alpine.gliderlabs.com/alpine/v3.5/community" >> /etc/apk/repositories \
-    && apk add --no-cache --virtual --update \
     glide \
 
     # Cleanup

--- a/README.md
+++ b/README.md
@@ -2,8 +2,11 @@
 
 Docker image that uses the latest and stable Golang and Glide as Package Dependency
 
-Golang 1.6.3-alpine
+Golang 1.7.3-alpine
 Glide 0.12.3-r0
+
+NOTE: Latest docker tag is deprecated and will no longer be maintained. Kindly use the specific docker tag name.
+Latest = 1.0.0
 
 Build-and-Run on the fly. This image also supports cMake for Makefile
 

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ NOTE: `latest` docker tag is now deprecated and will no longer be maintained. Ki
 `latest` tag is equivalent to tag `1.0.0`
 
 
-OFFICIAL DOCKER TAGS: 
+OFFICIAL DOCKER TAGS with Application Versions: 
 
-TAGS     | GoLang Version | Glide Version | Alpine Base Image Version
----      | ---      	  | ---           | ---
-1.1.0    | 1.7.3          | 0.12.3        | 3.5
-1.0.0    | 1.6.3          | 0.12.3        | 3.4
-latest   | 1.6.3          | 0.12.3        | 3.4
+TAGS     | GoLang | Glide   | GIT    | Alpine Base
+---      | ---    | ---     | ---    | ---
+1.1.0    | 1.7.3  | 0.12.3  | 2.11.1 | 3.5
+1.0.0    | 1.6.3  | 0.12.3  | 2.8.3  | 3.4
+latest   | 1.6.3  | 0.12.3  | 2.8.3  | 3.4 
 
 
 Build-and-Run on the fly. This image also supports cMake for Makefile

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Docker image that uses the latest and stable Golang and Glide as Package Depende
 Golang 1.7.3-alpine
 Glide 0.12.3-r0
 
-NOTE: Latest docker tag is deprecated and will no longer be maintained. Kindly use the specific docker tag name.
-Latest = 1.0.0
+NOTE: `latest` docker tag is now deprecated and will no longer be maintained. Kindly use the specific docker tag name.
+DOCKER TAG: latest = 1.0.0
 
 Build-and-Run on the fly. This image also supports cMake for Makefile
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,18 @@
 
 Docker image that uses the latest and stable Golang and Glide as Package Dependency
 
-Golang 1.7.3-alpine
-Glide 0.12.3-r0
-
 NOTE: `latest` docker tag is now deprecated and will no longer be maintained. Kindly use the specific docker tag name.
-DOCKER TAG: latest = 1.0.0
+`latest` tag is equivalent to tag `1.0.0`
+
+
+OFFICIAL DOCKER TAGS: 
+
+TAGS     | GoLang Version | Glide Version | Alpine Base Image Version
+---      | ---      	  | ---           | ---
+1.1.0    | 1.7.3          | 0.12.3        | 3.5
+1.0.0    | 1.6.3          | 0.12.3        | 3.4
+latest   | 1.6.3          | 0.12.3        | 3.4
+
 
 Build-and-Run on the fly. This image also supports cMake for Makefile
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ NOTE: `latest` docker tag is now deprecated and will no longer be maintained. Ki
 `latest` tag is equivalent to tag `1.0.0`
 
 
-OFFICIAL DOCKER TAGS with Application Versions: 
+OFFICIAL DOCKER TAGS WITH APPLICATION VERSIONS: 
 
 TAGS     | GoLang | Glide   | GIT    | Alpine Base
 ---      | ---    | ---     | ---    | ---


### PR DESCRIPTION
Contains the following version:
golang 1.7.3
glide 0.12.3
git 2.11.1
alpine base 3.5